### PR TITLE
[Chapter 3] Update `nginx-values.yaml` to match the template

### DIFF
--- a/Chapter 3/nginx/nginx-values.yaml
+++ b/Chapter 3/nginx/nginx-values.yaml
@@ -14,7 +14,6 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
       service.beta.kubernetes.io/aws-load-balancer-ssl-cert: 'arn:aws:acm:us-west-2:096198301477:certificate/b2a25df9-e051-4308-a213-f3ac610ef1f1'
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-      service.beta.kubernetes.io/aws-load-balancer-type: nlb
     targetPorts: 
       http: http
       https: 80


### PR DESCRIPTION
`aws-load-balancer-type` has been removed from [the template](https://github.com/mlops-on-kubernetes/Book/blob/a4c0ccc/Chapter%203/nginx/nginx-values.yaml.template) as of a4c0ccc.